### PR TITLE
[HOT-FIX] Prevent getting "bulk-delete" as ID

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -97,6 +97,8 @@ sylius_admin_product_variant_delete:
                 arguments:
                     id: $id
                     productId: $productId
+    requirements:
+        id: '\d+'
 
 sylius_admin_product_variant_generate:
     path: /generate

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
@@ -102,3 +102,5 @@ sylius_admin_promotion_coupon_delete:
             section: admin
             redirect: referer
             permission: true
+    requirements:
+        id: '\d+'


### PR DESCRIPTION
There are some changes in Symfony 4.1 routing wich spoils our routing files with "bulkDeleteAction"s... 😕 As a hot-fix I propose to require promotion coupon and product variant IDs to be number (they're autogenerated integers anyway).